### PR TITLE
ci: add Zephyr deploy summary action to CI

### DIFF
--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -169,6 +169,13 @@ jobs:
           ZE_API_GATE: ${{ env.ZE_API_GATE }}
           ZE_API: ${{ env.ZE_API }}
 
+      - name: Zephyr deploy summary
+        if: github.event_name == 'pull_request'
+        uses: ZephyrCloudIO/zephyr-preview-environment-action@main
+        id: zephyr-summary
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload build logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()


### PR DESCRIPTION
## Motivation, Context, Closing issues
This adds the Zephyr deploy summary step to the main CI workflow so pull requests get a consolidated preview/deploy summary directly in the PR.

## Proposed Changes
- Add a `Zephyr deploy summary` step to `.github/workflows/build-deploy-test.yml`
- Run the step only for `pull_request` events
- Use `ZephyrCloudIO/zephyr-preview-environment-action@main` with `github_token`

## Screenshots/Screen Recording:
N/A

## Other information
This is a CI-only change and does not affect runtime behavior of examples.