### PR TITLE
fix(ci): allow dispatch runs to bypass pnpm minimumReleaseAge

### DIFF
--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -70,6 +70,7 @@ env:
       github.event.inputs.environment == 'staging' && 'https://zephyr-api-prerelease-1a6b535d0499.herokuapp.com' ||
       'https://api.zephyr-cloud.io'
     }}
+  PNPM_INSTALL_FLAGS: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') && '--config.minimumReleaseAge=0' || '' }}
 
 jobs:
   build-deploy-test:
@@ -104,7 +105,7 @@ jobs:
       - name: Install scripts dependencies
         run: |
           cd scripts
-          pnpm install --prefer-offline
+          pnpm install --prefer-offline ${PNPM_INSTALL_FLAGS}
 
       - name: Upgrade Zephyr plugins
         if: github.event_name != 'pull_request' && github.event_name != 'push'
@@ -122,7 +123,7 @@ jobs:
           fi
 
       - name: Install example dependencies
-        run: pnpm install --prefer-offline
+        run: pnpm install --prefer-offline ${PNPM_INSTALL_FLAGS}
 
       - name: Install standalone example dependencies
         run: |
@@ -136,7 +137,7 @@ jobs:
             if [ -f "${example}/package.json" ]; then
               echo "Installing dependencies for ${example}"
               cd "$example"
-              pnpm install --prefer-offline
+              pnpm install --prefer-offline ${PNPM_INSTALL_FLAGS}
               cd "$GITHUB_WORKSPACE"
             fi
           done


### PR DESCRIPTION
## Summary
- add a single workflow-level `PNPM_INSTALL_FLAGS` env var that conditionally sets `--config.minimumReleaseAge=0` for `workflow_dispatch` and `repository_dispatch` runs
- reuse that flag across all `pnpm install` steps in `build-deploy-test.yml`
- keep default maturity protection unchanged for normal `push` and `pull_request` CI runs

## Why
- manual/dispatch plugin-version validation can fail with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` when testing freshly published versions
- this keeps security defaults intact for regular CI while unblocking explicit plugin test workflows

## Testing
- not run locally (workflow-only change)