### PR TITLE
fix(ci): unify dispatch pnpm install flags

### DIFF
--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -70,7 +70,7 @@ env:
       github.event.inputs.environment == 'staging' && 'https://zephyr-api-prerelease-1a6b535d0499.herokuapp.com' ||
       'https://api.zephyr-cloud.io'
     }}
-  PNPM_INSTALL_FLAGS: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') && '--config.minimumReleaseAge=0' || '' }}
+  PNPM_INSTALL_FLAGS: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch') && '--config.minimumReleaseAge=0 --no-frozen-lockfile' || '' }}
 
 jobs:
   build-deploy-test:


### PR DESCRIPTION
## Summary
- include `--no-frozen-lockfile` in `PNPM_INSTALL_FLAGS` for `workflow_dispatch` and `repository_dispatch`
- keep install command usage centralized around `PNPM_INSTALL_FLAGS`
- prevent standalone install failures after runtime plugin upgrades mutate `package.json`