### PR TITLE
fix(ci): provision Playwright browsers from official image (fix install hang)

### DIFF
--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -78,9 +78,8 @@ jobs:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     env:
-      # Extract/install browsers to the fast /tmp filesystem instead of the
-      # default $HOME/.cache/ms-playwright, which stalls on this runner.
-      # Honored by both `playwright install` and `playwright test`.
+      # Where browsers are provisioned (from the official Playwright image, see
+      # steps below) and where `playwright test` looks for them.
       PLAYWRIGHT_BROWSERS_PATH: /tmp/ms-playwright
     steps:
       - name: Checkout
@@ -208,34 +207,24 @@ jobs:
       # (~/.zephyr/storage), so they can't run in a separate job.
 
       # Root cause of the previous CI hang: `playwright install` downloads the
-      # browser fine (to /tmp) but then hangs forever extracting the archive into
-      # $HOME/.cache/ms-playwright — $HOME is on a slow/stalling filesystem on the
-      # runner. Pointing PLAYWRIGHT_BROWSERS_PATH at /tmp makes extraction land on
-      # the fast filesystem (the same one the download already writes to).
-      - name: Cache Playwright browsers
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: /tmp/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
-      - name: Install Playwright browsers
-        timeout-minutes: 15
+      # browser fine but then hangs forever at "extracting archive" on this
+      # runner (the bundled unzip stalls — and it is NOT the disk: `pnpm install`
+      # writes hundreds of thousands of files here without issue). Work around it
+      # by copying the already-extracted browsers out of the official Playwright
+      # image (proven to work) instead of running Playwright's extractor.
+      - name: Provision Playwright browsers (from official image)
+        timeout-minutes: 10
         run: |
-          cd scripts
-          for attempt in 1 2 3; do
-            echo "Installing Playwright browsers (attempt ${attempt}/3)..."
-            # Per-attempt hard timeout so a stall is killed and retried rather
-            # than hanging the whole step indefinitely.
-            if timeout --signal=KILL 240 npx playwright install chromium; then
-              exit 0
-            fi
-            echo "Attempt ${attempt} failed or timed out, retrying in 10s..."
-            sleep 10
-          done
-          echo "Failed to install Playwright browsers after 3 attempts"
-          exit 1
+          set -euo pipefail
+          # Keep this tag in sync with the @playwright/test version in pnpm-lock.yaml.
+          IMAGE="mcr.microsoft.com/playwright:v1.58.2-noble"
+          docker pull "$IMAGE"
+          CID=$(docker create "$IMAGE")
+          mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
+          docker cp "$CID:/ms-playwright/." "$PLAYWRIGHT_BROWSERS_PATH/"
+          docker rm "$CID"
+          echo "Provisioned browsers into $PLAYWRIGHT_BROWSERS_PATH:"
+          ls -1 "$PLAYWRIGHT_BROWSERS_PATH"
 
       - name: Run deployment validation tests
         run: |

--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -198,30 +198,62 @@ jobs:
           echo "Waiting 60 seconds for all deployments to propagate..."
           sleep 60
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
-      - name: Install Playwright browsers
-        timeout-minutes: 15
+      # --- TEMPORARY DIAGNOSTIC (#1) — remove once root cause is confirmed ---
+      # Reproduces the `playwright install` stall with verbose logging so we can
+      # see the exact point it hangs (download finalize vs. archive extraction).
+      # `continue-on-error` ensures it never blocks the pipeline — the real
+      # browsers are provided by the Playwright container in the `test` job.
+      - name: Diagnose Playwright install (DEBUG)
+        continue-on-error: true
+        timeout-minutes: 4
+        env:
+          DEBUG: pw:install
         run: |
           cd scripts
-          for attempt in 1 2 3; do
-            echo "Installing Playwright browsers (attempt ${attempt}/3)..."
-            # Per-attempt timeout so a stalled CDN download is killed and retried
-            # instead of hanging the whole step (playwright has no download timeout).
-            if timeout --signal=KILL 240 npx playwright install chromium; then
-              exit 0
-            fi
-            echo "Attempt ${attempt} failed or timed out, retrying in 10s..."
-            sleep 10
-          done
-          echo "Failed to install Playwright browsers after 3 attempts"
-          exit 1
+          timeout --signal=KILL 120 npx playwright install chromium
+
+  # Tests run against the live deployed URLs (baseURL: https://zephyrcloud.app),
+  # so this job only needs a browser + network — not the build outputs. Using
+  # the official Playwright image means browsers are pre-installed, removing the
+  # flaky `playwright install` download/extract step entirely.
+  test:
+    name: Run deployment validation tests
+    needs: build-deploy-test
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 20
+    # Keep this tag in sync with the @playwright/test version in pnpm-lock.yaml.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - name: Install scripts dependencies
+        run: |
+          cd scripts
+          pnpm install --prefer-offline ${PNPM_INSTALL_FLAGS}
 
       - name: Run deployment validation tests
         run: |

--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -77,6 +77,11 @@ jobs:
     name: Build, Deploy, and Test All Examples
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Extract/install browsers to the fast /tmp filesystem instead of the
+      # default $HOME/.cache/ms-playwright, which stalls on this runner.
+      # Honored by both `playwright install` and `playwright test`.
+      PLAYWRIGHT_BROWSERS_PATH: /tmp/ms-playwright
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -198,62 +203,39 @@ jobs:
           echo "Waiting 60 seconds for all deployments to propagate..."
           sleep 60
 
-      # --- TEMPORARY DIAGNOSTIC (#1) — remove once root cause is confirmed ---
-      # Reproduces the `playwright install` stall with verbose logging so we can
-      # see the exact point it hangs (download finalize vs. archive extraction).
-      # `continue-on-error` ensures it never blocks the pipeline — the real
-      # browsers are provided by the Playwright container in the `test` job.
-      - name: Diagnose Playwright install (DEBUG)
-        continue-on-error: true
-        timeout-minutes: 4
-        env:
-          DEBUG: pw:install
-        run: |
-          cd scripts
-          timeout --signal=KILL 120 npx playwright install chromium
+      # NOTE: the validation tests must stay in this job — they read the deploy
+      # results that `build-packages` wrote to zephyr-agent's local store
+      # (~/.zephyr/storage), so they can't run in a separate job.
 
-  # Tests run against the live deployed URLs (baseURL: https://zephyrcloud.app),
-  # so this job only needs a browser + network — not the build outputs. Using
-  # the official Playwright image means browsers are pre-installed, removing the
-  # flaky `playwright install` download/extract step entirely.
-  test:
-    name: Run deployment validation tests
-    needs: build-deploy-test
-    runs-on: depot-ubuntu-latest
-    timeout-minutes: 20
-    # Keep this tag in sync with the @playwright/test version in pnpm-lock.yaml.
-    container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
+      # Root cause of the previous CI hang: `playwright install` downloads the
+      # browser fine (to /tmp) but then hangs forever extracting the archive into
+      # $HOME/.cache/ms-playwright — $HOME is on a slow/stalling filesystem on the
+      # runner. Pointing PLAYWRIGHT_BROWSERS_PATH at /tmp makes extraction land on
+      # the fast filesystem (the same one the download already writes to).
+      - name: Cache Playwright browsers
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ${{ env.STORE_PATH }}
-          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: /tmp/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            pnpm-store-${{ runner.os }}-
+            playwright-${{ runner.os }}-
 
-      - name: Install scripts dependencies
+      - name: Install Playwright browsers
+        timeout-minutes: 15
         run: |
           cd scripts
-          pnpm install --prefer-offline ${PNPM_INSTALL_FLAGS}
+          for attempt in 1 2 3; do
+            echo "Installing Playwright browsers (attempt ${attempt}/3)..."
+            # Per-attempt hard timeout so a stall is killed and retried rather
+            # than hanging the whole step indefinitely.
+            if timeout --signal=KILL 240 npx playwright install chromium; then
+              exit 0
+            fi
+            echo "Attempt ${attempt} failed or timed out, retrying in 10s..."
+            sleep 10
+          done
+          echo "Failed to install Playwright browsers after 3 attempts"
+          exit 1
 
       - name: Run deployment validation tests
         run: |

--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -76,6 +76,7 @@ jobs:
   build-deploy-test:
     name: Build, Deploy, and Test All Examples
     runs-on: depot-ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -197,10 +198,30 @@ jobs:
           echo "Waiting 60 seconds for all deployments to propagate..."
           sleep 60
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright browsers
+        timeout-minutes: 15
         run: |
           cd scripts
-          npx playwright install chromium
+          for attempt in 1 2 3; do
+            echo "Installing Playwright browsers (attempt ${attempt}/3)..."
+            # Per-attempt timeout so a stalled CDN download is killed and retried
+            # instead of hanging the whole step (playwright has no download timeout).
+            if timeout --signal=KILL 240 npx playwright install chromium; then
+              exit 0
+            fi
+            echo "Attempt ${attempt} failed or timed out, retrying in 10s..."
+            sleep 10
+          done
+          echo "Failed to install Playwright browsers after 3 attempts"
+          exit 1
 
       - name: Run deployment validation tests
         run: |

--- a/scripts/playwright.config.js
+++ b/scripts/playwright.config.js
@@ -14,6 +14,11 @@ module.exports = defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    // The CI Playwright container runs as root; Chromium requires --no-sandbox
+    // to launch as root. Only applied in CI so local runs keep the sandbox.
+    launchOptions: {
+      args: process.env.CI ? ['--no-sandbox'] : [],
+    },
   },
   projects: [
     {

--- a/scripts/playwright.config.js
+++ b/scripts/playwright.config.js
@@ -14,11 +14,6 @@ module.exports = defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
-    // The CI Playwright container runs as root; Chromium requires --no-sandbox
-    // to launch as root. Only applied in CI so local runs keep the sandbox.
-    launchOptions: {
-      args: process.env.CI ? ['--no-sandbox'] : [],
-    },
   },
   projects: [
     {


### PR DESCRIPTION
## Problem

The **Install Playwright browsers** step (`npx playwright install chromium`) hung indefinitely in CI (~20 min until manually cancelled).

## Root cause (confirmed with \`DEBUG=pw:install\`)

The browser **downloads fine**, then Playwright hangs forever at the **archive extraction** step:

```
pw:install -- download complete, size: 175440843
pw:install SUCCESS downloading Chrome for Testing 145.0.7632.6
pw:install extracting archive        <-- last line, then silence until killed
```

Findings from iterating on the live runner (`depot-ubuntu-latest`):
- It is **deterministic**, not a transient CDN flake — every retry hangs at the exact same point.
- It is **not the network/download** — the 167 MiB zip downloads in ~0.5s.
- It is **not the disk / target filesystem** — relocating `PLAYWRIGHT_BROWSERS_PATH` to `/tmp` still hung, and `pnpm install` writes hundreds of thousands of files on the same runner without issue. Playwright's bundled unzip simply deadlocks in this environment.

The tests **must** run in the same job as the build/deploy: they read deploy results from `zephyr-agent`'s local store (`~/.zephyr/storage`) that `build-packages` writes during deploy, so they can't be split into a separate job.

## Fix

Skip Playwright's (hanging) extractor entirely: copy the already-extracted browsers out of the **official Playwright image** (`mcr.microsoft.com/playwright:v1.58.2-noble`) with `docker cp` into `PLAYWRIGHT_BROWSERS_PATH`, which `playwright test` then reads. Everything stays in the existing single job.

Also adds a `timeout-minutes: 30` job guardrail so nothing can hang for hours again.

## Result

Green end-to-end — browsers provisioned in seconds, tests run in the same job:

```
Provisioned browsers into /tmp/ms-playwright:
chromium-1208
ffmpeg-1011
Running 3 tests using 1 worker
    ✅ Passed: 43   ❌ Failed: 0   ⏭️ Skipped: 0   📊 Total: 43
  3 passed (2.3m)
```

## Maintenance note

Keep the image tag (`v1.58.2-noble`) in sync with the `@playwright/test` version in `pnpm-lock.yaml` so the provisioned browser revision matches.