### PR TITLE
test(ci): isolate Depot runner — run on ubuntu-latest [experiment, do not merge]

### DIFF
--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -75,7 +75,7 @@ env:
 jobs:
   build-deploy-test:
     name: Build, Deploy, and Test All Examples
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Purpose (experiment — do not merge)

Controlled A/B test to confirm the Playwright install hang (see #187) is specific to the **Depot runner**.

This branch is the **original, unfixed** workflow from `main` with a **single change**: `runs-on: depot-ubuntu-latest` → `runs-on: ubuntu-latest`. Nothing else.

## Expected outcome

- If the **Install Playwright browsers** step (which hangs at `extracting archive` on `depot-ubuntu-latest`) **passes** here → confirms the hang is Depot-specific.
- If it still hangs → the cause is not the runner, and we re-investigate.

Note: GitHub-hosted `ubuntu-latest` is smaller than the Depot runner, so the heavy build step may be slower or resource-constrained; that's unrelated to the Playwright question.