### PR TITLE
fix(ci): bump Playwright to 1.61.0 to fix browser install hang

### DIFF
--- a/.github/workflows/build-deploy-test.yml
+++ b/.github/workflows/build-deploy-test.yml
@@ -198,6 +198,7 @@ jobs:
           sleep 60
 
       - name: Install Playwright browsers
+        timeout-minutes: 5
         run: |
           cd scripts
           npx playwright install chromium

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1107,8 +1107,8 @@ importers:
         version: 1.0.1(https-proxy-agent@7.0.6)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.56.1
-        version: 1.58.2
+        specifier: ^1.61.0
+        version: 1.61.0
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -5245,8 +5245,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -14026,13 +14026,13 @@ packages:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -23415,9 +23415,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.61.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.61.0
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.1(esbuild@0.25.5)))(webpack@5.105.1(esbuild@0.25.5))':
     dependencies:
@@ -34137,11 +34137,11 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.61.0: {}
 
-  playwright@1.58.2:
+  playwright@1.61.0:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -28,7 +28,7 @@
     "@types/node-persist": "^3.1.8"
   },
   "devDependencies": {
-    "@playwright/test": "^1.56.1",
+    "@playwright/test": "^1.61.0",
     "@types/js-yaml": "^4.0.9",
     "typescript": "^5.8.2",
     "tsx": "^4.19.2"


### PR DESCRIPTION
## Problem

CI's **Install Playwright browsers** step hung indefinitely (~20 min until manually cancelled). With `@playwright/test` 1.58.2, the browser downloads fine, then Playwright hangs during **archive extraction** of the Chrome-for-Testing build (chromium v1208).

## Root cause

A bug in **Playwright 1.58.2's bundled archive extractor**, not the infrastructure. Verified with two controlled experiments:

- Switching the runner to GitHub-hosted `ubuntu-latest` hung at the identical point → **not the Depot runner**.
- Relocating extraction to `/tmp` also hung, while `pnpm install` writes far more files on the same runner without issue → **not the disk**.
- `DEBUG=pw:install` showed the download completing, then a permanent stall at `extracting archive`.

## Fix

Bump `@playwright/test` `^1.56.1` → `^1.61.0` (lockfile resolves to 1.61.0, chromium v1228). The install now downloads **and extracts** in seconds to the default cache path:

```
Chrome for Testing 149.0.7827.55 (chromium v1228) downloaded to .../chromium-1228
FFmpeg ... downloaded
Chrome Headless Shell ... downloaded
→ deployment validation tests: 43 passed, 0 failed
```

Also adds `timeout-minutes: 5` to the install step so any future download/extract stall fails fast instead of hanging the job.

## Notes

- No workaround needed (no `docker cp`, no `PLAYWRIGHT_BROWSERS_PATH` change, no container, no runner change).
- Supersedes the abandoned workaround in #187 and the runner experiment in #188.